### PR TITLE
Fix #1757 : ArrowResultSetConverter owns data of the produced RecordB…

### DIFF
--- a/QueryEngine/ArrowResultSet.h
+++ b/QueryEngine/ArrowResultSet.h
@@ -235,8 +235,8 @@ class ArrowResultSetConverter {
   std::vector<std::string> col_names_;
   int32_t top_n_;
 
-  mutable std::vector<std::unique_ptr<int8_t[]>> values_;
-  mutable std::vector<std::unique_ptr<uint8_t[]>> is_valid_;
+  mutable std::vector<std::shared_ptr<arrow::Buffer>> values_;
+  mutable std::vector<std::shared_ptr<arrow::Buffer>> is_valid_;
 
   friend class ArrowResultSet;
 };

--- a/QueryEngine/ArrowResultSet.h
+++ b/QueryEngine/ArrowResultSet.h
@@ -235,9 +235,6 @@ class ArrowResultSetConverter {
   std::vector<std::string> col_names_;
   int32_t top_n_;
 
-  mutable std::vector<std::shared_ptr<arrow::Buffer>> values_;
-  mutable std::vector<std::shared_ptr<arrow::Buffer>> is_valid_;
-
   friend class ArrowResultSet;
 };
 

--- a/QueryEngine/ArrowResultSetConverter.cpp
+++ b/QueryEngine/ArrowResultSetConverter.cpp
@@ -162,9 +162,8 @@ void convert_column(ResultSetPtr result,
   if (result->isZeroCopyColumnarConversionPossible(col)) {
     data_ptr = result->getColumnarBuffer(col);
   } else {
-    values.reset(new int8_t[entry_count * sizeof(C_TYPE)]);
-    result->copyColumnIntoBuffer(col, values.get(), entry_count * sizeof(C_TYPE));
-    data_ptr = values.get();
+    data_ptr = new int8_t[entry_count * sizeof(C_TYPE)];
+    result->copyColumnIntoBuffer(col, const_cast<int8_t*>(data_ptr), entry_count * sizeof(C_TYPE));
   }
 
   int64_t null_count = 0;

--- a/QueryEngine/ArrowResultSetConverter.cpp
+++ b/QueryEngine/ArrowResultSetConverter.cpp
@@ -164,14 +164,12 @@ void convert_column(ResultSetPtr result,
       reinterpret_cast<const uint8_t*>(
       result->getColumnarBuffer(col)), buf_size));
   } else {
-    values.reset();
     AllocateBuffer(buf_size, &values);
     result->copyColumnIntoBuffer(col, 
       reinterpret_cast<int8_t*>(values->mutable_data()), buf_size);
   }
 
   int64_t null_count = 0;
-  is_valid.reset();
   AllocateBuffer((entry_count + 7) / 8, &is_valid);
   auto is_valid_data = is_valid->mutable_data();
 


### PR DESCRIPTION
Splits data between converter and result in case of impossibility to implement Zero Copy Columnar Conversion. 