### PR TITLE
Fix memory leaks in omnisci embedded engine

### DIFF
--- a/Embedded/DBEngine.h
+++ b/Embedded/DBEngine.h
@@ -33,7 +33,7 @@ class Cursor {
   ColumnType getColType(uint32_t col_num);
   std::shared_ptr<arrow::RecordBatch> getArrowRecordBatch();
  protected:
-  Cursor(){}
+  Cursor() {}
   Cursor(const Cursor&) = delete;
   Cursor& operator=(const Cursor&) = delete;
 };
@@ -42,8 +42,8 @@ class DBEngine {
  public:
   void reset();
   void executeDDL(const std::string& query);
-  std::shared_ptr<Cursor> executeDML(const std::string& query);
-  std::shared_ptr<Cursor> executeRA(const std::string& query);
+  std::unique_ptr<Cursor> executeDML(const std::string& query);
+  std::unique_ptr<Cursor> executeRA(const std::string& query);
   void createArrowTable(const std::string&, std::shared_ptr<arrow::Table>& table);
   static DBEngine* create(const std::string& path = DEFAULT_DATABASE_PATH, int port = DEFAULT_CALCITE_PORT);
   static DBEngine* create(const std::map<std::string, std::string>& parameters);

--- a/Embedded/DBEngine.h
+++ b/Embedded/DBEngine.h
@@ -26,14 +26,14 @@ namespace EmbeddedDatabase {
 
 class Cursor {
  public:
+  virtual ~Cursor() {}
   size_t getColCount();
   size_t getRowCount();
   Row getNextRow();
   ColumnType getColType(uint32_t col_num);
   std::shared_ptr<arrow::RecordBatch> getArrowRecordBatch();
-
  protected:
-  Cursor() {}
+  Cursor(){}
   Cursor(const Cursor&) = delete;
   Cursor& operator=(const Cursor&) = delete;
 };
@@ -42,8 +42,8 @@ class DBEngine {
  public:
   void reset();
   void executeDDL(const std::string& query);
-  Cursor* executeDML(const std::string& query);
-  Cursor* executeRA(const std::string& query);
+  std::shared_ptr<Cursor> executeDML(const std::string& query);
+  std::shared_ptr<Cursor> executeRA(const std::string& query);
   void createArrowTable(const std::string&, std::shared_ptr<arrow::Table>& table);
   static DBEngine* create(const std::string& path = DEFAULT_DATABASE_PATH, int port = DEFAULT_CALCITE_PORT);
   static DBEngine* create(const std::map<std::string, std::string>& parameters);

--- a/Embedded/DBEngine.pxd
+++ b/Embedded/DBEngine.pxd
@@ -85,8 +85,8 @@ cdef extern from "DBEngine.h" namespace 'EmbeddedDatabase':
 
     cdef cppclass DBEngine:
         void executeDDL(string)
-        Cursor* executeDML(string)
-        Cursor* executeRA(string)
+        shared_ptr[Cursor] executeDML(string)
+        shared_ptr[Cursor] executeRA(string)
 #        shared_ptr[ResultSet] executeDML(string)
         vector[string] getTables()
         vector[ColumnDetails] getTableDetails(string)

--- a/Embedded/DBEngine.pxd
+++ b/Embedded/DBEngine.pxd
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from libc.stdint cimport int64_t, uint64_t, uint32_t, uint8_t
 from libcpp.map cimport map
-from libcpp.memory cimport shared_ptr
+from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.string cimport string
 from libcpp cimport bool, nullptr_t, nullptr
 from libcpp.pair cimport pair
@@ -85,9 +85,8 @@ cdef extern from "DBEngine.h" namespace 'EmbeddedDatabase':
 
     cdef cppclass DBEngine:
         void executeDDL(string)
-        shared_ptr[Cursor] executeDML(string)
-        shared_ptr[Cursor] executeRA(string)
-#        shared_ptr[ResultSet] executeDML(string)
+        unique_ptr[Cursor] executeDML(string)
+        unique_ptr[Cursor] executeRA(string)
         vector[string] getTables()
         vector[ColumnDetails] getTableDetails(string)
         void createArrowTable(string, shared_ptr[CTable]&)

--- a/Embedded/EmbeddedDbFSITest.cpp
+++ b/Embedded/EmbeddedDbFSITest.cpp
@@ -65,16 +65,6 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  if (!boost::filesystem::exists(base_path)) {
-    std::cerr << "Catalog basepath " + base_path + " does not exist.\n";
-    return 1;
-  }
-  std::string catalogs_path = base_path + "/mapd_catalogs";
-  if (!boost::filesystem::exists(catalogs_path)) {
-    std::cerr << "OmniSci catalogs is not  initialized at " + base_path << std::endl;
-    return 1;
-  }
-
   try {
     std::map<std::string, std::string> parameters = {
       {"path", base_path},
@@ -138,7 +128,7 @@ dropoff_puma BIGINT) WITH (storage_type='CSV:/localdisk1/amalakho/omniscidb/Test
       for (auto& item : schema) {
         std::cout << item.col_name << std::endl;
       }
-      Cursor* cursor = dbe->executeDML("select count(*) from test");
+      auto cursor = dbe->executeDML("select count(*) from test");
       if (cursor) {
         std::cout << cursor->getRowCount() << " rows selected" << std::endl;
         std::shared_ptr<arrow::RecordBatch> rbatch = cursor->getArrowRecordBatch();

--- a/Embedded/EmbeddedDbTest.cpp
+++ b/Embedded/EmbeddedDbTest.cpp
@@ -65,22 +65,11 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  if (!boost::filesystem::exists(base_path)) {
-    std::cerr << "Catalog basepath " + base_path + " does not exist.\n";
-    return 1;
-  }
-  std::string catalogs_path = base_path + "/mapd_catalogs";
-  if (!boost::filesystem::exists(catalogs_path)) {
-    std::cerr << "OmniSci catalogs is not  initialized at " + base_path << std::endl;
-    return 1;
-  }
-
   try {
-//    DBEngine* dbe = DBEngine::create(base_path);
     std::map<std::string, std::string> parameters = {
       {"path", base_path},
       {"port", std::to_string(calcite_port)}};
-    DBEngine* dbe = DBEngine::create(parameters);
+    auto dbe = DBEngine::create(parameters);
 
     if (dbe) {
       auto memory_pool = arrow::default_memory_pool();
@@ -116,7 +105,6 @@ int main(int argc, char* argv[]) {
         std::cerr << "Cursor is NULL" << std::endl;
       }
     }
-    delete dbe;
   } catch (std::exception& e) {
     std::cerr << "Exception: " << e.what() << "\n";
   }

--- a/Embedded/EmbeddedDbTest.cpp
+++ b/Embedded/EmbeddedDbTest.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
       for (auto& item : schema) {
         std::cout << item.col_name << std::endl;
       }
-      Cursor* cursor = dbe->executeDML("select * from test");
+      auto cursor = dbe->executeDML("select * from test");
       if (cursor) {
         std::cout << cursor->getRowCount() << " rows selected" << std::endl;
         std::shared_ptr<arrow::RecordBatch> rbatch = cursor->getArrowRecordBatch();

--- a/Embedded/dbe.pyx
+++ b/Embedded/dbe.pyx
@@ -106,22 +106,22 @@ cdef class PyRow:
 
 
 cdef class PyCursor:
-    cdef _Cursor* c_cursor  #Hold a C++ instance which we're wrapping
+    cdef shared_ptr[_Cursor] c_cursor  #Hold a C++ instance which we're wrapping
     cdef shared_ptr[CRecordBatch] c_batch
 
     def colCount(self):
-        return self.c_cursor.getColCount()
+        return self.c_cursor.get().getColCount()
 
     def rowCount(self):
-        return self.c_cursor.getRowCount()
+        return self.c_cursor.get().getRowCount()
 
     def nextRow(self):
         obj = PyRow()
-        obj.c_row = self.c_cursor.getNextRow()
+        obj.c_row = self.c_cursor.get().getNextRow()
         return obj
 
     def getColType(self, uint32_t pos):
-        obj = PyColumnType(<int>self.c_cursor.getColType(pos))
+        obj = PyColumnType(<int>self.c_cursor.get().getColType(pos))
         return obj
 
     def showRows(self, int max_rows=0):
@@ -146,7 +146,7 @@ cdef class PyCursor:
 
     def getArrowRecordBatch(self):
         with nogil:
-            self.c_batch = self.c_cursor.getArrowRecordBatch()
+            self.c_batch = self.c_cursor.get().getArrowRecordBatch()
         if self.c_batch.get() is NULL:
             print('Record batch is NULL')
             return None

--- a/Embedded/dbe.pyx
+++ b/Embedded/dbe.pyx
@@ -106,7 +106,7 @@ cdef class PyRow:
 
 
 cdef class PyCursor:
-    cdef shared_ptr[_Cursor] c_cursor  #Hold a C++ instance which we're wrapping
+    cdef unique_ptr[_Cursor] c_cursor  #Hold a C++ instance which we're wrapping
     cdef shared_ptr[CRecordBatch] c_batch
 
     def colCount(self):

--- a/Embedded/test/test_fsi.py
+++ b/Embedded/test/test_fsi.py
@@ -3,8 +3,10 @@ import numpy as np
 import pyarrow as pa
 from pyarrow import csv
 import dbe
+import ctypes
+ctypes._dlopen('libDBEngine.so', ctypes.RTLD_GLOBAL)
 
-d = dbe.PyDbEngine('data', 9092)
+d = dbe.PyDbEngine(path='data', port=9092)
 assert not d.closed
 print("DDL")
 r = d.executeDDL("""

--- a/Embedded/test/test_readcsv.py
+++ b/Embedded/test/test_readcsv.py
@@ -3,8 +3,10 @@ import numpy as np
 import pyarrow as pa
 from pyarrow import csv
 import dbe
+import ctypes
+ctypes._dlopen('libDBEngine.so', ctypes.RTLD_GLOBAL)
 
-d = dbe.PyDbEngine("data", 9091)
+d = dbe.PyDbEngine(path='data', port=9091)
 assert not d.closed
 root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 table = csv.read_csv(root + "/Tests/Import/datafiles/santander_top1000.csv")


### PR DESCRIPTION
Got rid of the list of cursors.
Replaced pointer to shared_ptr in cursor-returning functions.
Added a virtual destructor.
Updated tests.