### PR TITLE
Normalize when determine mapd root path

### DIFF
--- a/Shared/mapdpath.h
+++ b/Shared/mapdpath.h
@@ -73,7 +73,7 @@ inline std::string mapd_root_abs_path() {
   CHECK_GT(path_len, 0);
   CHECK_LT(static_cast<size_t>(path_len), sizeof(abs_exe_path));
   boost::filesystem::path abs_exe_dir(std::string(abs_exe_path, path_len));
-  abs_exe_dir.remove_filename();
+  abs_exe_dir.normalize().remove_filename();
 #ifdef XCODE
   const auto mapd_root = abs_exe_dir.parent_path().parent_path();
 #else


### PR DESCRIPTION
An attempt to fix cases when path to libDBEngine.so is like /p1/p2/p3/../..